### PR TITLE
lab_4_2 changes

### DIFF
--- a/labs/lab4/lab_4_2.b.s
+++ b/labs/lab4/lab_4_2.b.s
@@ -4,49 +4,28 @@
 .globl __start
 __start:
     # start of main program
-    la $a0,prompt
-    li $v0,4
-    syscall # display "Enter integer number :"
+    la $a0, prompt
+    li $v0, 4
+    syscall # display "Enter integer number: "
 
-    li $v0,5
+    li $v0, 5
     syscall # read integer
 
     move $a0, $v0       # move the integer that was given from the $v0 to $a0
     jal proc        # jump to procedure
 
-    move $t0,$v0        # move the result of the procedure from $v0 to $t0
+    move $t0, $v0        # move the result of the procedure from $v0 to $t0
 
-    la $a0,endl
-    li $v0,4
+    la $a0, endl
+    li $v0, 4
     syscall             # display end of line
-    move $a0,$t0
+    move $a0, $t0
 
-    li $v0,10
+    li $v0, 10
     syscall             # exit
+
 # end of main program
 # start of procedure
-#
-# proc: # Arguement: $a0 - integer number
-#         li $v0, 1
-#         syscall
-
-#         ble $a0, $zero, next    # if $a0 <= 0, stop the procedure
-#                                 # note: < is for case of $a0 being negative
-
-#         addi $sp, $sp, -4       # store the value of $a0 in stack
-#         sw $a0, 0($sp)
-
-#         la $a0,endl
-#         li $v0,4
-#         syscall                 # display end of line
-
-#         lw $a0, 0($sp)          # retrieve the old value of $a0 from stack
-#         addi $sp, $sp, 4
-
-#         addi $a0, $a0, -1       # decrease the value of $a0 by 1
-#         move $v0, $a0           # move the new decreased number to $v0, which holds the result of a procedure   
-#         j proc                  # jump to procedure, so it is recursive
-# end of procedure
 
 proc: # Arguement: $a0 - integer number
         addi $sp, $sp, -8       # store the value of $ra in stack
@@ -66,8 +45,8 @@ proc: # Arguement: $a0 - integer number
 
 proc_rec:
         move $t0, $a0           # move the value of $a0 to $t0
-        la $a0,endl
-        li $v0,4
+        la $a0, endl
+        li $v0, 4
         syscall                 # display end of line
         move $a0, $t0
 
@@ -83,13 +62,3 @@ proc_rec:
 .data
 prompt: .asciiz "Enter integer number:\n"
 endl: .asciiz "\n"
-
-
-
-# void printing_a0(int a0)
-# {
-#     printf("%d\n", a0);
-#     if (a0 <= 0)
-#         return;
-#     printing_a0(--a0);
-# }

--- a/labs/lab4/lab_4_2.b.s
+++ b/labs/lab4/lab_4_2.b.s
@@ -1,0 +1,60 @@
+#        Recursive Procedure with Stack  
+
+.text
+.globl __start
+__start:
+    # start of main program
+    la $a0,prompt
+    li $v0,4
+    syscall # display "Enter integer number :"
+
+    li $v0,5
+    syscall # read integer
+
+    addi $sp, $sp, -4   # store the value of $a0 in the stack so it isnt lost
+    sw $a0, 0($sp)
+
+    move $a0, $v0       # move the integer that was given from the $v0 to $a0
+    j proc              # jump to procedure
+    next:
+
+    lw $a0, 0($sp)
+    addi $sp, $sp, 4
+
+    move $t0,$v0        # move the result of the procedure from $v0 to $t0
+
+    la $a0,endl
+    li $v0,4
+    syscall             # display end of line
+    move $a0,$t0
+
+    li $v0,10
+    syscall             # exit
+# end of main program
+# start of procedure
+#
+    proc: # Arguement: $a0 - integer number
+        li $v0, 1
+        syscall
+
+        ble $a0, $zero, next    # if $a0 <= 0, stop the procedure
+                                # note: < is for case of $a0 being negative
+
+        addi $sp, $sp, -4       # store the value of $a0 in stack
+        sw $a0, 0($sp)
+
+        la $a0,endl
+        li $v0,4
+        syscall                 # display end of line
+
+        lw $a0, 0($sp)          # retrieve the old value of $a0 from stack
+        addi $sp, $sp, 4
+
+        addi $a0, $a0, -1       # decrease the value of $a0 by 1
+        move $v0, $a0           # move the new decreased number to $v0, which holds the result of a procedure   
+        j proc                  # jump to precdure, so it is recursive
+# end of procedure
+
+.data
+prompt: .asciiz "Enter integer number:\n"
+endl: .asciiz "\n"

--- a/labs/lab4/lab_4_2.b.s
+++ b/labs/lab4/lab_4_2.b.s
@@ -11,15 +11,8 @@ __start:
     li $v0,5
     syscall # read integer
 
-    addi $sp, $sp, -4   # store the value of $a0 in the stack so it isnt lost
-    sw $a0, 0($sp)
-
     move $a0, $v0       # move the integer that was given from the $v0 to $a0
-    j proc              # jump to procedure
-    next:
-
-    lw $a0, 0($sp)
-    addi $sp, $sp, 4
+    jal proc        # jump to procedure
 
     move $t0,$v0        # move the result of the procedure from $v0 to $t0
 
@@ -33,28 +26,70 @@ __start:
 # end of main program
 # start of procedure
 #
-    proc: # Arguement: $a0 - integer number
-        li $v0, 1
+# proc: # Arguement: $a0 - integer number
+#         li $v0, 1
+#         syscall
+
+#         ble $a0, $zero, next    # if $a0 <= 0, stop the procedure
+#                                 # note: < is for case of $a0 being negative
+
+#         addi $sp, $sp, -4       # store the value of $a0 in stack
+#         sw $a0, 0($sp)
+
+#         la $a0,endl
+#         li $v0,4
+#         syscall                 # display end of line
+
+#         lw $a0, 0($sp)          # retrieve the old value of $a0 from stack
+#         addi $sp, $sp, 4
+
+#         addi $a0, $a0, -1       # decrease the value of $a0 by 1
+#         move $v0, $a0           # move the new decreased number to $v0, which holds the result of a procedure   
+#         j proc                  # jump to procedure, so it is recursive
+# end of procedure
+
+proc: # Arguement: $a0 - integer number
+        addi $sp, $sp, -8       # store the value of $ra in stack
+        sw $t0, 0($sp)
+        sw $ra, 4($sp)
+
+        li $v0, 1               # print $a0
         syscall
 
-        ble $a0, $zero, next    # if $a0 <= 0, stop the procedure
+        sle $t0, $a0, $zero     # if $a0 <= 0, stop the procedure
                                 # note: < is for case of $a0 being negative
+        beq $t0, $zero, proc_rec    # if $a0 > 0, jump to proc_rec
 
-        addi $sp, $sp, -4       # store the value of $a0 in stack
-        sw $a0, 0($sp)
+        # Base case: $a0 <= 0
+        addi $sp, $sp, 8
+        jr $ra                  # return to the caller
 
+proc_rec:
+        move $t0, $a0           # move the value of $a0 to $t0
         la $a0,endl
         li $v0,4
         syscall                 # display end of line
-
-        lw $a0, 0($sp)          # retrieve the old value of $a0 from stack
-        addi $sp, $sp, 4
+        move $a0, $t0
 
         addi $a0, $a0, -1       # decrease the value of $a0 by 1
-        move $v0, $a0           # move the new decreased number to $v0, which holds the result of a procedure   
-        j proc                  # jump to precdure, so it is recursive
-# end of procedure
+        jal proc                # jump to procedure, so it is recursive
+
+        lw $ra, 4($sp)          # retrieve the old value of $ra from stack
+        lw $t0, 0($sp)          # retrieve the old value of $t0 from stack
+        addi $sp, $sp, 8
+
+        jr $ra                  # return to the caller
 
 .data
 prompt: .asciiz "Enter integer number:\n"
 endl: .asciiz "\n"
+
+
+
+# void printing_a0(int a0)
+# {
+#     printf("%d\n", a0);
+#     if (a0 <= 0)
+#         return;
+#     printing_a0(--a0);
+# }

--- a/labs/lab4/lab_4_2_a.s
+++ b/labs/lab4/lab_4_2_a.s
@@ -33,11 +33,12 @@ __start:
 # end of main program
 # start of procedure
 #
-    proc:
-        beq $a0, $zero, next    # if the value of the $a0, which represent
-                                # the given number of the procedure is equual to 0 the procedure stops
+    proc: # Arguement: $a0 - integer number
         li $v0, 1
         syscall
+
+        ble $a0, $zero, next    # if $a0 <= 0, stop the procedure
+                                # note: < is for case of $a0 being negative
 
         addi $sp, $sp, -4       # store the value of $a0 in stack
         sw $a0, 0($sp)
@@ -55,5 +56,5 @@ __start:
 # end of procedure
 
 .data
-prompt: .asciiz "Enter integer number :"
+prompt: .asciiz "Enter integer number:\n"
 endl: .asciiz "\n"


### PR DESCRIPTION
### In lab_4_2_a.s:
- Fixed the implementation of the procedure by printing the $a0 argument before the base check (so 0 is printed, based on the exercise's description)
- Changed `beq $a0, $zero, next` to `ble $a0, $zero, next`, to support cases of `$a0 <= 0`
- Small change in prompt

### lab_4_2_b.s:
- New implementation of lab_4_2 based on the ```sw $ra, offset($sp) ..... jr $ra``` recursion approach
- Stores $t0 instead of $a0 in the stack, based on the exercise's description

Note to make: lab_4_2_a.s is technically a loop, not recursion.